### PR TITLE
auto dark/light theme

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -25,11 +25,33 @@ const INDEX_HTML: &str = r#"<!DOCTYPE html>
 <html>
 <head>
     <title>Textpod</title>
+    <meta name="color-scheme" content="light dark"/>
     <link rel="shortcut icon" href="data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjQiIGhlaWdodD0iMjQiIGZpbGw9ImN1cnJlbnRDb2xvciIgdmlld0JveD0iMCAwIDI0IDI0IiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciPjxwYXRoIGQ9J00xMS42NjkgMi4yODJjLjIxOC0uMDQzLjQ0My0uMDQzLjY2MiAwIC4yNTEuMDQ4LjQ3OS4xNjcuNjkxLjI3N2wuMDUzLjAyOCA4LjI3IDQuMjhhLjc1Ljc1IDAgMCAxIC40MDUuNjY2djcuODk3YzAgLjI4My4wMDIuNTgzLS4wOTMuODYyYTEuNzU4IDEuNzU4IDAgMCAxLS4zOTUuNjUyYy0uMjA1LjIxNC0uNDczLjM1MS0uNzIzLjQ4bC0uMDYzLjAzMy04LjEzMSA0LjIwOGEuNzUuNzUgMCAwIDEtLjY5IDBsLTguMTMxLTQuMjA4LS4wNjMtLjAzM2MtLjI1LS4xMjktLjUxOC0uMjY2LS43MjMtLjQ4YTEuNzU5IDEuNzU5IDAgMCAxLS4zOTUtLjY1MmMtLjA5NS0uMjgtLjA5NC0uNTgtLjA5My0uODYzVjcuNTMzYS43NS43NSAwIDAgMSAuNDA1LS42NjZsOC4yNjktNC4yOC4wNTMtLjAyN2MuMjEzLS4xMTEuNDQtLjIzLjY5Mi0uMjc4bS4yMjYgMS40OTZhNi41NzkgNi41NzkgMCAwIDAtLjI4Mi4xNDFMNC42NjggNy41MTQgMTIgMTEuMTAybDcuMzMyLTMuNTg4LTYuOTQ2LTMuNTk1YTYuNTA1IDYuNTA1IDAgMCAwLS4yODItLjE0MS40OC40OCAwIDAgMC0uMDU4LS4wMjRtLS43OTYgMTYuMDEzdi03LjM2MmwtNy41LTMuNjd2Ni42MjRjMCAuMTg3IDAgLjI5NC4wMDUuMzc1YS40OTYuNDk2IDAgMCAwIC4wMDkuMDc4LjI1OC4yNTggMCAwIDAgLjA1Ny4wOTVjLjAwNS4wMDQuMDIxLjAxNy4wNjQuMDQyLjA2OC4wNDIuMTYzLjA5LjMyOC4xNzZ6bS42NDUtMTUuOTlhLjQ4My40ODMgMCAwIDEgLjA2LS4wMjN6Jy8+PC9zdmc+" />
     <style>
+        @media (prefers-color-scheme: light) {
+            .timestamp {
+                color: #666;
+            }
+            .note code {
+                background-color: #dedcd1;
+            }
+            .note pre {
+                background-color: #dedcd1;
+            }
+        }
+        @media (prefers-color-scheme: dark) {
+            .timestamp {
+                color: #BBB;
+            }
+            .note code {
+                background-color: #3a3a3a;
+            }
+            .note pre {
+                background-color: #3a3a3a;
+            }
+        }
         html {
             height: 100%;
-            background-color: rgb(238 236 225);
         }
         body {
             font-family: system-ui, -apple-system, sans-serif;
@@ -57,22 +79,19 @@ const INDEX_HTML: &str = r#"<!DOCTYPE html>
             padding-top: 0.25em;
         }
         .note code {
-            background-color: #dedcd1;
             padding: 0.25em;
         }
         .note pre {
-            background-color: #dedcd1;
             padding: 0.5em;
         }
         .note pre code {
-            background-color: transparent;
             padding: 0;
+            background-color: transparent;
         }
         .note img, .note iframe, .note video, .note audio, .note embed, .note svg {
             max-width: 100%;
         }
         .timestamp {
-            color: #666;
             font-size: 0.9em;
             margin-bottom: 0.25em;
             font-family: monospace;


### PR DESCRIPTION
Hi, thanks for this awesome project! I've been doing the "one file" thing for notes for a bit, and this is a great riff on that idea.

Anyway, this PR add automatic dark/light themes based on the browser/os color scheme. Looks like this:

![image](https://github.com/user-attachments/assets/4fa259d1-226c-4584-83bf-258d1abe387f)
