### PR TITLE
dont ship full rust dev environment when a couple of binaries are enough

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,12 +1,17 @@
-FROM rust:latest
+FROM rust:alpine AS build
 
-RUN cargo install monolith
+RUN apk add musl-dev perl make
 RUN cargo install textpod
+RUN cargo install monolith
+
+FROM alpine
+COPY --from=build /usr/local/cargo/bin/textpod /usr/bin/textpod
+COPY --from=build /usr/local/cargo/bin/monolith /usr/bin/monolith
 
 WORKDIR /app/notes
 
 HEALTHCHECK --interval=60s --retries=3 --timeout=1s \
-CMD curl -f http://localhost:3000/ || exit 1
+CMD nc -z -w 1 localhost 3000 || exit 1
 
 ENTRYPOINT ["textpod"]
 CMD ["-p", "3000", "-l", "0.0.0.0"]


### PR DESCRIPTION
The current docker image includes all of rust and the size is >500MB. This way it should be <25MB