### PR TITLE
make textpod behave a little more "REST-y"

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -107,7 +107,6 @@
         .note svg {
             max-width: 100%;
         }
-
     </style>
 </head>
 
@@ -132,8 +131,44 @@
             if (searchQuery) {
                 editor.value = '/' + decodeURIComponent(searchQuery);
                 performSearch(searchQuery);
+            } else {
+                loadNotes();
             }
         });
+
+        async function loadNotes() {
+            let response = await fetch('/notes');
+            if (response.ok) {
+                notes.innerHTML = '';
+                const notes = await response.json();
+                notes.forEach((note, i) => {
+                    let container = document.createElement('div');
+                    container.className = 'note';
+                    container.id = `note-${i}`;
+
+                    let metadata = document.createElement('div');
+                    metadata.className = 'noteMetadata';
+
+                    let time = document.createElement('time');
+                    time.innerHTML = note.timestamp;
+                    metadata.appendChild(time);
+
+                    let deleteLink = document.createElement('a');
+                    deleteLink.href = '#';
+                    deleteLink.onclick = () => deleteNote(event, container);
+                    deleteLink.innerHTML = 'delete';
+
+                    metadata.appendChild(document.createTextNode(' ['));
+                    metadata.appendChild(deleteLink);
+                    metadata.appendChild(document.createTextNode(']'));
+
+                    container.innerHTML = note.html;
+                    container.appendChild(metadata);
+
+                    notesDiv.appendChild(container);
+                });
+            }
+        }
 
         async function performSearch(query) {
             const response = await fetch(`/search/${encodeURIComponent(query)}`);
@@ -219,7 +254,7 @@
             }
         });
 
-        submitButton.addEventListener('click', async(e) => {
+        submitButton.addEventListener('click', async (e) => {
             saveNotes();
         })
 

--- a/src/index.html
+++ b/src/index.html
@@ -115,109 +115,71 @@
     <textarea id="editor"
         placeholder="Ctrl+Enter to save.&#10;Type / to search.&#10;Drag & drop files to attach.&#10;Start links with + to save local copies."></textarea>
     <div id="submitContainer"><button id="submitButton">Submit</button></div>
-    <div id="notes">{{NOTES}}</div>
+    <div id="notes"></div>
 
     <script>
         const editor = document.getElementById('editor');
         const notesDiv = document.getElementById('notes');
         const submitButton = document.getElementById('submitButton');
         let searchTimeout = null;
-        let originalNotes = notesDiv.innerHTML;
 
-        // Check for search parameter on page load
-        window.addEventListener('load', () => {
-            const params = new URLSearchParams(window.location.search);
-            const searchQuery = params.get('q');
-            if (searchQuery) {
-                editor.value = '/' + decodeURIComponent(searchQuery);
-                performSearch(searchQuery);
-            } else {
-                loadNotes();
-            }
+        window.addEventListener('load', async () => {
+            displayNotes();
         });
 
-        async function loadNotes() {
+        // fetches and displays all notes, optionally filtering them based on the query parameter `q`
+        async function displayNotes() {
+            const params = new URLSearchParams(window.location.search);
+            const searchQuery = params.get('q');
             let response = await fetch('/notes');
             if (response.ok) {
-                notes.innerHTML = '';
                 const notes = await response.json();
-                notes.forEach((note, i) => {
-                    let container = document.createElement('div');
-                    container.className = 'note';
-                    container.id = `note-${i}`;
-
-                    let metadata = document.createElement('div');
-                    metadata.className = 'noteMetadata';
-
-                    let time = document.createElement('time');
-                    time.innerHTML = note.timestamp;
-                    metadata.appendChild(time);
-
-                    let deleteLink = document.createElement('a');
-                    deleteLink.href = '#';
-                    deleteLink.onclick = () => deleteNote(event, container);
-                    deleteLink.innerHTML = 'delete';
-
-                    metadata.appendChild(document.createTextNode(' ['));
-                    metadata.appendChild(deleteLink);
-                    metadata.appendChild(document.createTextNode(']'));
-
-                    container.innerHTML = note.html;
-                    container.appendChild(metadata);
-
-                    notesDiv.appendChild(container);
-                });
+                notesDiv.innerHTML = notes
+                    .filter(note => !searchQuery || note.content.includes(searchQuery))
+                    .map((note, i) => `
+                    <div class="note">
+                        ${note.html}
+                        <div class="noteMetadata">
+                            <time datetime="${note.timestamp}">${note.timestamp}</time>
+                            [<a href="#" onclick="deleteNote(${i})">delete</a>]
+                        </div>
+                    </div>`)
+                    .reverse() // TODO implement user-specified sorting (reverse chronological by default)
+                    .join('');
             }
         }
 
-        async function performSearch(query) {
-            const response = await fetch(`/search/${encodeURIComponent(query)}`);
-            if (response.ok) {
-                const notes = await response.json();
-                displayNotes(notes);
-            }
-        }
-
+        // saves a new note and refreshes the page
         async function saveNotes() {
             if (!editor.value) {
                 return;
             }
-            const response = await fetch('/save', {
+            const saveResponse = await fetch('/notes', {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json' },
                 body: JSON.stringify(editor.value)
             });
 
-            if (response.ok) {
+            // TODO more efficient way to do this than reloading all notes every time
+            if (saveResponse.ok) {
                 editor.value = '';
-                // Clear search parameter from URL when saving
-                window.history.replaceState({}, '', window.location.pathname);
-
-                const notesResponse = await fetch('/');
-                if (notesResponse.ok) {
-                    const text = await notesResponse.text();
-                    const tempDiv = document.createElement('div');
-                    tempDiv.innerHTML = text;
-                    const newNotes = tempDiv.querySelector('#notes').innerHTML;
-                    notesDiv.innerHTML = newNotes;
-                    originalNotes = newNotes;
-                }
+                displayNotes();
             }
         }
 
-        async function deleteNote(event, element) {
+        // deletes note with index `idx`
+        async function deleteNote(idx) {
             event.preventDefault();
             if (!confirm('Are you sure you want to delete this note?')) {
                 return;
             }
 
-            const timestamp = element.getAttribute('data-timestamp');
-            const response = await fetch(`/delete/${timestamp}`, {
-                method: 'DELETE',
+            deleteResponse = await fetch(`/notes/${idx}`, {
+                method: 'DELETE'
             });
 
-            if (response.ok) {
-                element.closest('.note').remove();
+            if (deleteResponse.ok) {
+                displayNotes();
             } else {
                 alert('Failed to delete note');
             }
@@ -237,14 +199,11 @@
                         : window.location.pathname;
                     window.history.replaceState({}, '', newUrl);
 
-                    if (query) {
-                        await performSearch(query);
-                    }
-                }, 100);
+                    displayNotes();
+                }, 200);
             } else if (text === '') {
                 // Clear search parameter from URL
                 window.history.replaceState({}, '', window.location.pathname);
-                notesDiv.innerHTML = originalNotes;
             }
         });
 
@@ -296,15 +255,7 @@
             }
         });
 
-        function displayNotes(notes) {
-            notesDiv.innerHTML = notes
-                .map(note => `
-                    <div class="note">
-                        ${note.html}
-                        <time datetime="${note.timestamp}">${note.timestamp}</time>
-                    </div>`)
-                .join('');
-        }
+
     </script>
 </body>
 

--- a/src/index.html
+++ b/src/index.html
@@ -135,7 +135,7 @@
             if (response.ok) {
                 const notes = await response.json();
                 notesDiv.innerHTML = notes
-                    .filter(note => !searchQuery || note.content.includes(searchQuery))
+                    .filter(note => !searchQuery || note.content.toLowerCase().includes(searchQuery.toLowerCase()))
                     .map((note, i) => `
                     <div class="note">
                         ${note.html}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,9 +1,8 @@
 use axum::{
-    extract::{DefaultBodyLimit, Multipart},
-    extract::{Path, State},
+    extract::{DefaultBodyLimit, Multipart, Path, State},
     http::StatusCode,
-    response::Html,
-    routing::{delete, get, post},
+    response::{Html, IntoResponse},
+    routing::{get, post},
     Json, Router,
 };
 use base64::{display::Base64Display, engine::general_purpose::STANDARD};
@@ -73,11 +72,12 @@ async fn main() {
 
     let app = Router::new()
         .route("/", get(index))
-        .route("/notes", get(get_notes))
-        .route("/save", post(save_note))
-        .route("/search/:query", get(search_notes))
+        .route("/notes", get(get_notes).post(save_note))
+        .route(
+            "/notes/:index",
+            get(get_note_by_index).delete(delete_note_by_index),
+        ) // TODO PUT/PATCH
         .route("/upload", post(upload_file))
-        .route("/delete/:timestamp", delete(delete_note))
         .layer(DefaultBodyLimit::max(CONTENT_LENGTH_LIMIT))
         .nest_service("/attachments", ServeDir::new("attachments"))
         .with_state(state);
@@ -86,7 +86,7 @@ async fn main() {
     let addr: SocketAddr = server_details
         .parse()
         .expect("Unable to parse socket address");
-    println!("Starting server on http://{}", addr);
+    info!("Starting server on http://{}", addr);
 
     match tokio::net::TcpListener::bind(&addr).await {
         Ok(listener) => {
@@ -132,30 +132,63 @@ fn load_notes() -> Vec<Note> {
 
 // route / (root)
 async fn index(State(state): State<AppState>) -> Html<String> {
-    let notes = state.notes.lock().unwrap();
-    let notes_html = notes
-        .iter()
-        .rev()
-        .map(|note| {
-            format!(
-                "<div class=\"note\">{}<div class=\"noteMetadata\"><time datetime=\"{}\">{}</time> [<a href=\"#\" data-timestamp=\"{}\" onclick=\"deleteNote(event, this)\">delete</a>]</div></div>",
-                note.html, note.timestamp, note.timestamp, note.timestamp
-            )
-        })
-        .collect::<Vec<_>>()
-        .join("\n");
-
-    let html = state.html.replace("{{NOTES}}", &notes_html);
-    Html(html)
+    Html(state.html)
 }
 
 // GET /notes
 async fn get_notes(State(state): State<AppState>) -> Json<Vec<Note>> {
     let notes = state.notes.lock().unwrap();
-    Json(notes.iter().rev().cloned().collect::<Vec<_>>())
+    Json(notes.iter().cloned().collect::<Vec<_>>())
 }
 
-// route /save
+// GET /notes/:index
+async fn get_note_by_index(
+    State(state): State<AppState>,
+    Path(index): Path<usize>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let notes = state.notes.lock().unwrap();
+    if index >= notes.len() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("request for non-existent note #{index}"),
+        ));
+    }
+
+    return Ok(Json(notes.iter().collect::<Vec<_>>()[index].clone()));
+}
+
+// DELETE /notes/:index
+async fn delete_note_by_index(
+    State(state): State<AppState>,
+    Path(index): Path<usize>,
+) -> Result<impl IntoResponse, (StatusCode, String)> {
+    let mut notes = state.notes.lock().unwrap();
+    if index >= notes.len() {
+        return Err((
+            StatusCode::BAD_REQUEST,
+            format!("request for non-existent note #{index}"),
+        ));
+    }
+
+    notes.remove(index);
+
+    // Update the notes.md file
+    let content = notes
+        .iter()
+        .map(|note| format!("{}\n{}\n\n---\n\n", note.timestamp, note.content))
+        .collect::<String>();
+
+    if let Err(e) = fs::write("notes.md", content) {
+        return Err((StatusCode::INTERNAL_SERVER_ERROR, e.to_string()));
+    }
+
+    info!("Note deleted: {}", index);
+
+    // TODO return the deleted note, maybe?
+    return Ok(StatusCode::NO_CONTENT);
+}
+
+// POST /notes
 async fn save_note(
     State(state): State<AppState>,
     Json(content): Json<String>,
@@ -256,44 +289,6 @@ async fn save_note(
     }
 
     Ok(())
-}
-
-// route DELETE /delete/{timestamp}
-async fn delete_note(
-    State(state): State<AppState>,
-    Path(timestamp): Path<String>,
-) -> Result<(), StatusCode> {
-    let mut notes = state.notes.lock().unwrap();
-
-    // Find and remove the note with matching timestamp
-    if let Some(index) = notes.iter().position(|note| note.timestamp == timestamp) {
-        notes.remove(index);
-
-        // Update the notes.md file
-        let content = notes
-            .iter()
-            .map(|note| format!("{}\n{}\n\n---\n\n", note.timestamp, note.content))
-            .collect::<String>();
-
-        fs::write("notes.md", content).map_err(|_| StatusCode::INTERNAL_SERVER_ERROR)?;
-
-        info!("Note deleted: {}", timestamp);
-        Ok(())
-    } else {
-        error!("Note not found: {}", timestamp);
-        Err(StatusCode::NOT_FOUND)
-    }
-}
-
-// route GET /search/{query}
-async fn search_notes(State(state): State<AppState>, Path(query): Path<String>) -> Json<Vec<Note>> {
-    let notes = state.notes.lock().unwrap();
-    let filtered: Vec<Note> = notes
-        .iter()
-        .filter(|note| note.content.to_lowercase().contains(&query.to_lowercase()))
-        .cloned()
-        .collect();
-    Json(filtered)
 }
 
 // route POST /upload

--- a/src/main.rs
+++ b/src/main.rs
@@ -73,6 +73,7 @@ async fn main() {
 
     let app = Router::new()
         .route("/", get(index))
+        .route("/notes", get(get_notes))
         .route("/save", post(save_note))
         .route("/search/:query", get(search_notes))
         .route("/upload", post(upload_file))
@@ -146,6 +147,12 @@ async fn index(State(state): State<AppState>) -> Html<String> {
 
     let html = state.html.replace("{{NOTES}}", &notes_html);
     Html(html)
+}
+
+// GET /notes
+async fn get_notes(State(state): State<AppState>) -> Json<Vec<Note>> {
+    let notes = state.notes.lock().unwrap();
+    Json(notes.iter().rev().cloned().collect::<Vec<_>>())
 }
 
 // route /save


### PR DESCRIPTION
This PR primarily does 2 things:

1) Makes the backend server expose CRUD operations (mostly - "Update" is still unimplemented) in a more REST-ful way, and
2) Makes the frontend Javascript responsible for the rendering and search functionality

It adds a new `/notes` endpoint that returns JSON payloads of `Vec<Note>`, and uses the indices within that Vec to be able to directly address individual notes. This has a handful of upshots:

* Both the server and the frontend Javascript now maintain the same state ordering of Notes. For example, the frontend is responsible for putting the notes into reverse chronological order at display time (which opens a path for user-selectable sorting).
* ...which means that order within the `Vec<Note>` now matters (which I think is fine, but is something to be aware of).
* Any change to any Note now requires refreshing all Notes...which I also think is fine for the common use case, but could be optimized as a future enhancement (I have a couple of ideas on this).
* Paves the way fairly easily implementing Update/Edit functionality (unimplemented at present).
* Paves the way for an individual-note display mode (unimplemented, but should be easy to implement).

