### PR TITLE
allow for specifying a different base directory and notes filename

### DIFF
--- a/src/index.html
+++ b/src/index.html
@@ -217,6 +217,10 @@
             saveNotes();
         })
 
+        editor.addEventListener('paste', (e) => {
+            console.log(e);
+        });
+
         editor.addEventListener('dragover', (e) => {
             e.preventDefault();
         });

--- a/src/main.rs
+++ b/src/main.rs
@@ -41,7 +41,7 @@ struct Args {
     #[arg(short, long, default_value = "127.0.0.1")]
     listen: String,
     /// Save notes in FILE
-    #[arg(short='f', long, value_name="FILE", default_value = "notes.md")]
+    #[arg(short = 'f', long, value_name = "FILE", default_value = "notes.md")]
     notes_file: PathBuf,
 }
 


### PR DESCRIPTION
Example: `textpod -C /foo/bar -n todos.md`

^ This would use the directory `/foo/bar` for storing notes/attachments (instead of `.`), with notes being saved in `/foo/bar/todos.md`.