### PR TITLE
Allow for specifying a different timezone for Docker containers

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,6 +8,8 @@ FROM alpine
 COPY --from=build /usr/local/cargo/bin/textpod /usr/bin/textpod
 COPY --from=build /usr/local/cargo/bin/monolith /usr/bin/monolith
 
+RUN apk add --no-cache tzdata
+
 WORKDIR /app/notes
 
 HEALTHCHECK --interval=60s --retries=3 --timeout=1s \

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,3 +8,5 @@ services:
             - './notes:/app/notes'
         container_name: textpod
         restart: unless-stopped
+        environment:
+            - TZ=UTC


### PR DESCRIPTION
Currently when running Textpod in Docker, the system timezone is set to UTC and cannot be changed.
This PR allows for specifying a different timezone for Docker containers.

This fixes #34.