### PR TITLE
Fix docker healthcheck

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,12 +8,12 @@ FROM alpine
 COPY --from=build /usr/local/cargo/bin/textpod /usr/bin/textpod
 COPY --from=build /usr/local/cargo/bin/monolith /usr/bin/monolith
 
-RUN apk add --no-cache tzdata
+RUN apk add --no-cache tzdata curl
 
 WORKDIR /app/notes
 
 HEALTHCHECK --interval=60s --retries=3 --timeout=1s \
-CMD nc -z -w 1 localhost 3000 || exit 1
+CMD curl --silent --fail http://localhost:3000/ || exit 1
 
 ENTRYPOINT ["textpod"]
 CMD ["-p", "3000", "-l", "0.0.0.0"]


### PR DESCRIPTION
The netcat command was failing, causing the  container to constantly stay in an unhealthy state.

Using `curl` not only works, but also correctly detects HTTP errors.