### PR TITLE
Add a graceful shutdown

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,7 +10,7 @@ readme = "README.md"
 
 [dependencies]
 axum = { version = "0.7.7", features = ["multipart"] }
-tokio = { version = "1.41.1", features = ["full"] }
+tokio = { version = "1.41.1", features = ["full", "signal"] }
 tower-http = { version = "0.6.1", features = ["fs"] }
 comrak = "0.29"
 serde = { version = "1.0.215", features = ["derive"] }

--- a/src/main.rs
+++ b/src/main.rs
@@ -128,7 +128,7 @@ async fn shutdown() {
     let ctrl_c = async {
         tokio::signal::ctrl_c()
             .await
-            .expect("Failed to isntall ctrl + c handler");
+            .expect("Failed to install ctrl + c handler");
     };
 
     #[cfg(unix)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -114,15 +114,37 @@ async fn main() {
         .expect("Unable to parse socket address");
     info!("Starting server on http://{}", addr);
 
-    match tokio::net::TcpListener::bind(&addr).await {
-        Ok(listener) => {
-            if let Err(e) = axum::serve(listener, app).await {
-                error!("Server error: {}", e);
-            }
+    if let Ok(listener) = tokio::net::TcpListener::bind(&addr).await {
+        if let Err(e) = axum::serve(listener, app)
+            .with_graceful_shutdown(shutdown())
+            .await
+        {
+            error!("Server error: {}", e);
         }
-        Err(e) => {
-            error!("Failed to bind to address {}: {}", addr, e);
-        }
+    }
+}
+
+async fn shutdown() {
+    let ctrl_c = async {
+        tokio::signal::ctrl_c()
+            .await
+            .expect("Failed to isntall ctrl + c handler");
+    };
+
+    #[cfg(unix)]
+    let terminate = async {
+        tokio::signal::unix::signal(tokio::signal::unix::SignalKind::terminate())
+            .expect("It's supposed to run in a unix system.")
+            .recv()
+            .await;
+    };
+
+    #[cfg(not(unix))]
+    let terminate = std::future::pending::<()>();
+
+    tokio::select! {
+        _ = ctrl_c => {},
+        _ = terminate => {},
     }
 }
 


### PR DESCRIPTION
I was using textpod in podman, and after sending SIGTERM/SIGINT the application wasn't closing, which forced me to send a SIGKILL.

So, i added a simple graceful shutdown. i hope it can be useful for you.