### PR TITLE
Enable hard line breaks

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -374,6 +374,7 @@ fn md_to_html(markdown: &str) -> String {
     options.extension.tasklist = true;
     options.extension.superscript = true;
     options.render.unsafe_ = true;
+    options.render.hardbreaks = true;
     markdown_to_html(markdown, &options)
 }
 


### PR DESCRIPTION
Enables hard line breaks in Markdown rendering so that single newlines are displayed as line breaks without requiring two trailing spaces.